### PR TITLE
Adds assertion of content headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 
 dotnet_style_coalesce_expression = true:suggestion

--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -191,7 +191,7 @@ namespace HttpClientTestHelpers
         /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
         public HttpRequestMessageAsserter Times(int count)
         {
-            if(count < 0)
+            if (count < 0)
             {
                 throw new ArgumentException("Count should not be less than zero", nameof(count));
             }

--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -162,7 +162,7 @@ namespace HttpClientTestHelpers
             {
                 throw new ArgumentNullException(nameof(headerName));
             }
-            return With(x => x.HasHeader(headerName), $"header '{headerName}'");
+            return With(x => x.HasRequestHeader(headerName), $"header '{headerName}'");
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace HttpClientTestHelpers
             {
                 throw new ArgumentNullException(nameof(headerValue));
             }
-            return With(x => x.HasHeader(headerName, headerValue), $"header '{headerName}' and value '{headerValue}'");
+            return With(x => x.HasRequestHeader(headerName, headerValue), $"header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>

--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -187,6 +187,41 @@ namespace HttpClientTestHelpers
         }
 
         /// <summary>
+        /// Asserts whether requests were made with a specific header name. Values are ignored.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpContentHeader"/></remarks>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
+        public HttpRequestMessageAsserter WithContentHeader(string headerName)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+            return With(x => x.HasContentHeader(headerName), $"content header '{headerName}'");
+        }
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name and value.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpContentHeader"/></remarks>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
+        /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
+        public HttpRequestMessageAsserter WithContentHeader(string headerName, string headerValue)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                throw new ArgumentNullException(nameof(headerValue));
+            }
+            return With(x => x.HasContentHeader(headerName, headerValue), $"content header '{headerName}' and value '{headerValue}'");
+        }
+
+        /// <summary>
         /// Asserts that a specific amount of requests were made.
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>

--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -154,24 +154,26 @@ namespace HttpClientTestHelpers
         /// <summary>
         /// Asserts whether requests were made with a specific header name. Values are ignored.
         /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpRequestHeader"/></remarks>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
-        public HttpRequestMessageAsserter WithHeader(string headerName)
+        public HttpRequestMessageAsserter WithRequestHeader(string headerName)
         {
             if (string.IsNullOrEmpty(headerName))
             {
                 throw new ArgumentNullException(nameof(headerName));
             }
-            return With(x => x.HasRequestHeader(headerName), $"header '{headerName}'");
+            return With(x => x.HasRequestHeader(headerName), $"request header '{headerName}'");
         }
 
         /// <summary>
         /// Asserts whether requests were made with a specific header name and value.
         /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpRequestHeader"/></remarks>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
-        public HttpRequestMessageAsserter WithHeader(string headerName, string headerValue)
+        public HttpRequestMessageAsserter WithRequestHeader(string headerName, string headerValue)
         {
             if (string.IsNullOrEmpty(headerName))
             {
@@ -181,7 +183,7 @@ namespace HttpClientTestHelpers
             {
                 throw new ArgumentNullException(nameof(headerValue));
             }
-            return With(x => x.HasRequestHeader(headerName, headerValue), $"header '{headerName}' and value '{headerValue}'");
+            return With(x => x.HasRequestHeader(headerName, headerValue), $"request header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -96,10 +96,11 @@ namespace HttpClientTestHelpers
         /// <summary>
         /// Determines whether a specific header is set on a request.
         /// </summary>
+        /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpRequestHeaders"/></remarks>
         /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
         /// <param name="headerName">The name of the header to locate on the request.</param>
         /// <returns>true when the request contains a header with the specified name; otherwise, false.</returns>
-        public static bool HasHeader(this HttpRequestMessage httpRequestMessage, string headerName)
+        public static bool HasRequestHeader(this HttpRequestMessage httpRequestMessage, string headerName)
         {
             if (httpRequestMessage == null)
             {
@@ -117,11 +118,12 @@ namespace HttpClientTestHelpers
         /// <summary>
         /// Determines whether a specific header with a specific value is set on a request.
         /// </summary>
+        /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpRequestHeaders"/></remarks>
         /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
         /// <param name="headerName">The name of the header to locate on the request.</param>
         /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
         /// <returns>true when the request contains a header with the specified name and value; otherwise, false.</returns>
-        public static bool HasHeader(this HttpRequestMessage httpRequestMessage, string headerName, string headerValue)
+        public static bool HasRequestHeader(this HttpRequestMessage httpRequestMessage, string headerName, string headerValue)
         {
             if (httpRequestMessage == null)
             {

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 
 namespace HttpClientTestHelpers
@@ -112,7 +113,7 @@ namespace HttpClientTestHelpers
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return httpRequestMessage.Headers.Contains(headerName);
+            return httpRequestMessage.Headers.HasHeader(headerName);
         }
 
         /// <summary>
@@ -140,13 +141,7 @@ namespace HttpClientTestHelpers
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            if (httpRequestMessage.Headers.TryGetValues(headerName, out var values))
-            {
-                var value = string.Join(" ", values);
-                return Matches(value, headerValue);
-            }
-
-            return false;
+            return httpRequestMessage.Headers.HasHeader(headerName, headerValue);
         }
 
         /// <summary>
@@ -173,7 +168,7 @@ namespace HttpClientTestHelpers
                 return false;
             }
 
-            return httpRequestMessage.Content.Headers.Contains(headerName);
+            return httpRequestMessage.Content.Headers.HasHeader(headerName);
         }
 
         /// <summary>
@@ -206,7 +201,17 @@ namespace HttpClientTestHelpers
                 return false;
             }
 
-            if (httpRequestMessage.Content.Headers.TryGetValues(headerName, out var values))
+            return httpRequestMessage.Content.Headers.HasHeader(headerName, headerValue);
+        }
+
+        private static bool HasHeader(this HttpHeaders headers, string headerName)
+        {
+            return headers.Contains(headerName);
+        }
+
+        private static bool HasHeader(this HttpHeaders headers, string headerName, string headerValue)
+        {
+            if (headers.TryGetValues(headerName, out var values))
             {
                 var value = string.Join(" ", values);
                 return Matches(value, headerValue);

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -150,6 +150,72 @@ namespace HttpClientTestHelpers
         }
 
         /// <summary>
+        /// Determines whether a specific header is set on a request.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpContentHeaders"/></remarks>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
+        /// <param name="headerName">The name of the header to locate on the request.</param>
+        /// <returns>true when the request contains a header with the specified name; otherwise, false.</returns>
+        public static bool HasContentHeader(this HttpRequestMessage httpRequestMessage, string headerName)
+        {
+            if (httpRequestMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpRequestMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (httpRequestMessage.Content == null)
+            {
+                return false;
+            }
+
+            return httpRequestMessage.Content.Headers.Contains(headerName);
+        }
+
+        /// <summary>
+        /// Determines whether a specific header with a specific value is set on a request.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpContentHeaders"/></remarks>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
+        /// <param name="headerName">The name of the header to locate on the request.</param>
+        /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
+        /// <returns>true when the request contains a header with the specified name and value; otherwise, false.</returns>
+        public static bool HasContentHeader(this HttpRequestMessage httpRequestMessage, string headerName, string headerValue)
+        {
+            if (httpRequestMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpRequestMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                throw new ArgumentNullException(nameof(headerValue));
+            }
+
+            if (httpRequestMessage.Content == null)
+            {
+                return false;
+            }
+
+            if (httpRequestMessage.Content.Headers.TryGetValues(headerName, out var values))
+            {
+                var value = string.Join(" ", values);
+                return Matches(value, headerValue);
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Determines whether the request uri matches a pattern.
         /// </summary>
         /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>

--- a/src/HttpClientTestHelpers/TestableHttpMessageHandler.cs
+++ b/src/HttpClientTestHelpers/TestableHttpMessageHandler.cs
@@ -25,7 +25,7 @@ namespace HttpClientTestHelpers
         {
             httpRequestMessages.Enqueue(request);
 
-            if(response is TimeoutHttpResponseMessage)
+            if (response is TimeoutHttpResponseMessage)
             {
                 throw new TaskCanceledException(new OperationCanceledException().Message);
             }

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-
+using System.Text;
 using Xunit;
 
 namespace HttpClientTestHelpers.Tests
@@ -278,6 +278,137 @@ namespace HttpClientTestHelpers.Tests
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
             var result = sut.WithRequestHeader("api-version", "1.0");
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+#nullable disable
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithContentHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContentHeader(headerName));
+
+            Assert.Equal("headerName", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void WithContentHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'Content-Type', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage() });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'Content-Type', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter()
+        {
+            var request = new HttpRequestMessage();
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var result = sut.WithContentHeader("Content-Type");
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+#nullable disable
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithContentHeaderNameAndValue_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContentHeader(headerName, "someValue"));
+
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithContentHeaderNameAndValue_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContentHeader("someHeader", headerValue));
+
+            Assert.Equal("headerValue", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void WithContentHeaderNameAndValue_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("someHeader", "someValue"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'someHeader' and value 'someValue', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeaderNameAndValue_RequestWithoutHeaders_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage();
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type", "application/json"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'Content-Type' and value 'application/json', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeaderNameAndValue_RequestWithNotMatchingHeaderName_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage();
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type", "application/json"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'Content-Type' and value 'application/json', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeaderNameAndValue_RequestWithNotMatchingHeaderValue_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage();
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type", "application/json"));
+
+            Assert.Equal("Expected at least one request to be made with content header 'Content-Type' and value 'application/json', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContentHeaderNameAndValue_RequestWithMatchinHeader_ReturnsHttpRequestMessageAssert()
+        {
+            var request = new HttpRequestMessage();
+            request.Content = new StringContent("", Encoding.UTF8, "application/json");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var result = sut.WithContentHeader("Content-Type", "application/json");
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
@@ -156,44 +156,44 @@ namespace HttpClientTestHelpers.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        public void WithRequestHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader(headerName));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
         }
 #nullable restore
 
         [Fact]
-        public void WithHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("api-version"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version"));
 
-            Assert.Equal("Expected at least one request to be made with header 'api-version', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'api-version', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage() });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("api-version"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version"));
 
-            Assert.Equal("Expected at least one request to be made with header 'api-version', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'api-version', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter()
+        public void WithRequestHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter()
         {
             var request = new HttpRequestMessage();
             request.Headers.Add("api-version", "1.0");
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var result = sut.WithHeader("api-version");
+            var result = sut.WithRequestHeader("api-version");
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);
@@ -203,11 +203,11 @@ namespace HttpClientTestHelpers.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithHeaderNameAndValue_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        public void WithRequestHeaderNameAndValue_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader(headerName, "someValue"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader(headerName, "someValue"));
 
             Assert.Equal("headerName", exception.ParamName);
         }
@@ -215,69 +215,69 @@ namespace HttpClientTestHelpers.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithHeaderNameAndValue_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        public void WithRequestHeaderNameAndValue_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader("someHeader", headerValue));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader("someHeader", headerValue));
 
             Assert.Equal("headerValue", exception.ParamName);
         }
 #nullable restore
 
         [Fact]
-        public void WithHeaderNameAndValue_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("someHeader", "someValue"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("someHeader", "someValue"));
 
-            Assert.Equal("Expected at least one request to be made with header 'someHeader' and value 'someValue', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'someHeader' and value 'someValue', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeaderNameAndValue_RequestWithoutHeaders_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_RequestWithoutHeaders_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var request = new HttpRequestMessage();
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("api-version", "1.0"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
 
-            Assert.Equal("Expected at least one request to be made with header 'api-version' and value '1.0', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeaderNameAndValue_RequestWithNotMatchingHeaderName_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_RequestWithNotMatchingHeaderName_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var request = new HttpRequestMessage();
             request.Headers.Add("no-api-version", "1.0");
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("api-version", "1.0"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
 
-            Assert.Equal("Expected at least one request to be made with header 'api-version' and value '1.0', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeaderNameAndValue_RequestWithNotMatchingHeaderValue_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_RequestWithNotMatchingHeaderValue_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var request = new HttpRequestMessage();
             request.Headers.Add("api-version", "unknown");
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("api-version", "1.0"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
 
-            Assert.Equal("Expected at least one request to be made with header 'api-version' and value '1.0', but no requests were made.", exception.Message);
+            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
         }
 
         [Fact]
-        public void WithHeaderNameAndValue_RequestWithMatchinHeader_ReturnsHttpRequestMessageAssert()
+        public void WithRequestHeaderNameAndValue_RequestWithMatchinHeader_ReturnsHttpRequestMessageAssert()
         {
             var request = new HttpRequestMessage();
             request.Headers.Add("api-version", "1.0");
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var result = sut.WithHeader("api-version", "1.0");
+            var result = sut.WithRequestHeader("api-version", "1.0");
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContenttHeader.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContenttHeader.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Xunit;
+
+namespace HttpClientTestHelpers.Tests
+{
+    public partial class HttpRequestMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasContentHeader_NullRequest_ThrowsArgumentNullException()
+        {
+            HttpRequestMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition"));
+            Assert.Equal("httpRequestMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NullHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpRequestMessage();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader(headerName));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasContentHeader_NullRequestNonNullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException()
+        {
+            HttpRequestMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition", "inline"));
+            Assert.Equal("httpRequestMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpRequestMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader(headerName, "inline"));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NonNullHeaderNameAndNullHeaderValue_ThrowsArgumentNullException(string headerValue)
+        {
+            using var sut = new HttpRequestMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition", headerValue));
+            Assert.Equal("headerValue", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void HasContentHeader_ExistingHeaderName_ReturnsTrue()
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = new StringContent("");
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("inline");
+
+            Assert.True(sut.HasContentHeader("Content-Disposition"));
+        }
+
+        [Fact]
+        public void HasContentHeader_NotExistingHeaderName_ReturnsFalse()
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = new StringContent("");
+
+            Assert.False(sut.HasContentHeader("Content-Disposition"));
+        }
+
+        [Fact]
+        public void HasContentHeader_NoContent_ReturnsFalse()
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = null;
+
+            Assert.False(sut.HasContentHeader("Content-Disposition"));
+        }
+
+        [Theory]
+        [InlineData("inline; filename=empty.file")]
+        [InlineData("inline; *")]
+        [InlineData("*; filename=empty.file")]
+        [InlineData("*")]
+        public void HasContentHeader_ExistingHeaderNameMatchingValue_ReturnsTrue(string value)
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = new StringContent("");
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("inline")
+            {
+                FileName = "empty.file"
+            };
+
+            Assert.True(sut.HasContentHeader("Content-Disposition", value));
+        }
+
+        [Theory]
+        [InlineData("inline; filename=emtpy.file")]
+        [InlineData("inline; *")]
+        [InlineData("*; filename=empty.file")]
+        public void HasContentHeader_ExistingHeaderNameNotMatchingValue_ReturnsFalse(string value)
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = new StringContent("");
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "attachment.file"
+            };
+
+            Assert.False(sut.HasContentHeader("Content-Disposition", value));
+        }
+    }
+}

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasRequestHeader.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasRequestHeader.cs
@@ -9,70 +9,70 @@ namespace HttpClientTestHelpers.Tests
     {
 #nullable disable
         [Fact]
-        public void HasHeader_NullRequest_ThrowsArgumentNullException()
+        public void HasRequestHeader_NullRequest_ThrowsArgumentNullException()
         {
             HttpRequestMessage sut = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHeader("host"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasRequestHeader("host"));
             Assert.Equal("httpRequestMessage", exception.ParamName);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void HasHeader_NullHeaderName_ThrowsArgumentNullException(string headerName)
+        public void HasRequestHeader_NullHeaderName_ThrowsArgumentNullException(string headerName)
         {
             using var sut = new HttpRequestMessage();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHeader(headerName));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasRequestHeader(headerName));
             Assert.Equal("headerName", exception.ParamName);
         }
 
         [Fact]
-        public void HasHeader_NullRequestNonNullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException()
+        public void HasRequestHeader_NullRequestNonNullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException()
         {
             HttpRequestMessage sut = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHeader("host", "value"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasRequestHeader("host", "value"));
             Assert.Equal("httpRequestMessage", exception.ParamName);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void HasHeader_NullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException(string headerName)
+        public void HasRequestHeader_NullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException(string headerName)
         {
             using var sut = new HttpRequestMessage();
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHeader(headerName, "value"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasRequestHeader(headerName, "value"));
             Assert.Equal("headerName", exception.ParamName);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void HasHeader_NonNullHeaderNameAndNullHeaderValue_ThrowsArgumentNullException(string headerValue)
+        public void HasRequestHeader_NonNullHeaderNameAndNullHeaderValue_ThrowsArgumentNullException(string headerValue)
         {
             using var sut = new HttpRequestMessage();
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHeader("Host", headerValue));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasRequestHeader("Host", headerValue));
             Assert.Equal("headerValue", exception.ParamName);
         }
 #nullable restore
 
         [Fact]
-        public void HasHeader_ExistingHeaderName_ReturnsTrue()
+        public void HasRequestHeader_ExistingHeaderName_ReturnsTrue()
         {
             using var sut = new HttpRequestMessage();
             sut.Headers.Host = "example.com";
 
-            Assert.True(sut.HasHeader("Host"));
+            Assert.True(sut.HasRequestHeader("Host"));
         }
 
         [Fact]
-        public void HasHeader_NotExistingHeaderName_ReturnsFalse()
+        public void HasRequestHeader_NotExistingHeaderName_ReturnsFalse()
         {
             using var sut = new HttpRequestMessage();
 
-            Assert.False(sut.HasHeader("Host"));
+            Assert.False(sut.HasRequestHeader("Host"));
         }
 
         [Theory]
@@ -80,24 +80,24 @@ namespace HttpClientTestHelpers.Tests
         [InlineData("example*")]
         [InlineData("*.com")]
         [InlineData("*")]
-        public void HasHeader_ExistingHeaderNameMatchingValue_ReturnsTrue(string value)
+        public void HasRequestHeader_ExistingHeaderNameMatchingValue_ReturnsTrue(string value)
         {
             using var sut = new HttpRequestMessage();
             sut.Headers.Host = "example.com";
 
-            Assert.True(sut.HasHeader("Host", value));
+            Assert.True(sut.HasRequestHeader("Host", value));
         }
 
         [Theory]
         [InlineData("example.com")]
         [InlineData("example*")]
         [InlineData("*.com")]
-        public void HasHeader_ExistingHeaderNameNotMatchingValue_ReturnsFalse(string value)
+        public void HasRequestHeader_ExistingHeaderNameNotMatchingValue_ReturnsFalse(string value)
         {
             using var sut = new HttpRequestMessage();
             sut.Headers.Host = "myhost.net";
 
-            Assert.False(sut.HasHeader("Host", value));
+            Assert.False(sut.HasRequestHeader("Host", value));
         }
     }
 }


### PR DESCRIPTION
Content headers can now be asserted using `WithContentHeader`
`WithHeader` has been renamed to `WithRequestHeader` in order to make it more consistent with the underlying API.