### PR TITLE
Added WithHeader assertion.

### DIFF
--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -222,6 +222,39 @@ namespace HttpClientTestHelpers
         }
 
         /// <summary>
+        /// Asserts whether requests were made with a specific header name. Values are ignored.
+        /// </summary>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
+        public HttpRequestMessageAsserter WithHeader(string headerName)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+            return With(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), $"header '{headerName}'");
+        }
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name and value.
+        /// </summary>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
+        /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
+        public HttpRequestMessageAsserter WithHeader(string headerName, string headerValue)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                throw new ArgumentNullException(nameof(headerValue));
+            }
+            return With(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), $"header '{headerName}' and value '{headerValue}'");
+        }
+
+        /// <summary>
         /// Asserts that a specific amount of requests were made.
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -113,7 +113,7 @@ namespace HttpClientTestHelpers
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return httpRequestMessage.Headers.TryGetValues(headerName, out _);
+            return httpRequestMessage.Headers.HasHeader(headerName);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace HttpClientTestHelpers
                 return false;
             }
 
-            return httpRequestMessage.Content.Headers.TryGetValues(headerName, out _);
+            return httpRequestMessage.Content.Headers.HasHeader(headerName);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace HttpClientTestHelpers
 
         private static bool HasHeader(this HttpHeaders headers, string headerName)
         {
-            return headers.Contains(headerName);
+            return headers.TryGetValues(headerName, out _);
         }
 
         private static bool HasHeader(this HttpHeaders headers, string headerName, string headerValue)

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -113,7 +113,7 @@ namespace HttpClientTestHelpers
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return httpRequestMessage.Headers.HasHeader(headerName);
+            return httpRequestMessage.Headers.TryGetValues(headerName, out _);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace HttpClientTestHelpers
                 return false;
             }
 
-            return httpRequestMessage.Content.Headers.HasHeader(headerName);
+            return httpRequestMessage.Content.Headers.TryGetValues(headerName, out _);
         }
 
         /// <summary>

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
@@ -414,6 +414,147 @@ namespace HttpClientTestHelpers.Tests
             Assert.IsType<HttpRequestMessageAsserter>(result);
         }
 
+#nullable disable
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader(headerName));
+
+            Assert.Equal("headerName", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void WithHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("Content-Type"));
+
+            Assert.Equal("Expected at least one request to be made with header 'Content-Type', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage() });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("Content-Type"));
+
+            Assert.Equal("Expected at least one request to be made with header 'Content-Type', but no requests were made.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Host")]
+        [InlineData("Content-Type")]
+        public void WithHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter(string headerName)
+        {
+            var request = new HttpRequestMessage();
+            request.Headers.Host = "host";
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var result = sut.WithHeader(headerName);
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+#nullable disable
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithHeaderNameAndValue_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader(headerName, "someValue"));
+
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithHeaderNameAndValue_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHeader("someHeader", headerValue));
+
+            Assert.Equal("headerValue", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void WithHeaderNameAndValue_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("someHeader", "someValue"));
+
+            Assert.Equal("Expected at least one request to be made with header 'someHeader' and value 'someValue', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithHeaderNameAndValue_RequestWithoutHeaders_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage();
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("Content-Type", "application/json"));
+
+            Assert.Equal("Expected at least one request to be made with header 'Content-Type' and value 'application/json', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithHeaderNameAndValue_RequestWithNotMatchingHeaderName_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage();
+            request.Headers.Host = "test";
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader("Content-Disposition", "inline"));
+
+            Assert.Equal("Expected at least one request to be made with header 'Content-Disposition' and value 'inline', but no requests were made.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Content-Type", "application/json")]
+        [InlineData("Host", "Test")]
+        public void WithHeaderNameAndValue_RequestWithNotMatchingHeaderValue_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage(string name, string value)
+        {
+            var request = new HttpRequestMessage();
+            request.Headers.Host = "example";
+            request.Content = new StringContent("");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHeader(name, value));
+
+            Assert.Equal($"Expected at least one request to be made with header '{name}' and value '{value}', but no requests were made.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Content-Type", "application/json")]
+        [InlineData("Host", "Test")]
+        public void WithHeaderNameAndValue_RequestWithMatchinHeader_ReturnsHttpRequestMessageAssert(string name, string value)
+        {
+            var request = new HttpRequestMessage();
+            request.Headers.Host = "Test";
+            request.Content = new StringContent("", Encoding.UTF8, "application/json");
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var result = sut.WithHeader(name, value);
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
         [Fact]
         public void Times_ValueLessThan0_ThrowsArgumentException()
         {

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContentHeader.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContentHeader.cs
@@ -68,13 +68,15 @@ namespace HttpClientTestHelpers.Tests
             Assert.True(sut.HasContentHeader("Content-Disposition"));
         }
 
-        [Fact]
-        public void HasContentHeader_NotExistingHeaderName_ReturnsFalse()
+        [Theory]
+        [InlineData("Host")]
+        [InlineData("Content-Disposition")]
+        public void HasContentHeader_NotExistingHeaderName_ReturnsFalse(string headerName)
         {
             using var sut = new HttpRequestMessage();
             sut.Content = new StringContent("");
 
-            Assert.False(sut.HasContentHeader("Content-Disposition"));
+            Assert.False(sut.HasContentHeader(headerName));
         }
 
         [Fact]
@@ -101,6 +103,15 @@ namespace HttpClientTestHelpers.Tests
             };
 
             Assert.True(sut.HasContentHeader("Content-Disposition", value));
+        }
+
+        [Fact]
+        public void HasContentHeader_NotExitingHeaderNameAndValue_ReturnsFalse()
+        {
+            using var sut = new HttpRequestMessage();
+            sut.Content = new StringContent("");
+
+            Assert.False(sut.HasContentHeader("Host", "inline"));
         }
 
         [Theory]

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasRequestHeader.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasRequestHeader.cs
@@ -67,12 +67,14 @@ namespace HttpClientTestHelpers.Tests
             Assert.True(sut.HasRequestHeader("Host"));
         }
 
-        [Fact]
-        public void HasRequestHeader_NotExistingHeaderName_ReturnsFalse()
+        [Theory]
+        [InlineData("Host")]
+        [InlineData("Content-Type")]
+        public void HasRequestHeader_NotExistingHeaderName_ReturnsFalse(string headerName)
         {
             using var sut = new HttpRequestMessage();
 
-            Assert.False(sut.HasRequestHeader("Host"));
+            Assert.False(sut.HasRequestHeader(headerName));
         }
 
         [Theory]
@@ -86,6 +88,14 @@ namespace HttpClientTestHelpers.Tests
             sut.Headers.Host = "example.com";
 
             Assert.True(sut.HasRequestHeader("Host", value));
+        }
+
+        [Fact]
+        public void HasRequestHeader_NotExitingHeaderNameAndValue_ReturnsFalse()
+        {
+            using var sut = new HttpRequestMessage();
+
+            Assert.False(sut.HasRequestHeader("Content-Type"));
         }
 
         [Theory]


### PR DESCRIPTION
Previously it was only possible to assert `WithRequestHeaders` and `WithContentHeaders`, which is in line with how the HttpHeaders are implemented. However, for convenience the `WithHeader` is added which checks both the RequestHeaders and the ContentHeaders.

Closes #5 