### PR TITLE
Added WithContent assertion

### DIFF
--- a/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageAsserter.cs
@@ -255,6 +255,21 @@ namespace HttpClientTestHelpers
         }
 
         /// <summary>
+        /// Asserts whether requests were made with specific content.
+        /// </summary>
+        /// <param name="pattern">The expected content, supports wildcards.</param>
+        /// <returns>The <seealso cref="HttpRequestMessageAsserter"/> for further assertions.</returns>
+        public HttpRequestMessageAsserter WithContent(string pattern)
+        {
+            if(pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            return With(x => x.HasContent(pattern), $"content '{pattern}'");
+        }
+
+        /// <summary>
         /// Asserts that a specific amount of requests were made.
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>

--- a/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientTestHelpers/HttpRequestMessageExtensions.cs
@@ -98,7 +98,7 @@ namespace HttpClientTestHelpers
         /// Determines whether a specific header is set on a request.
         /// </summary>
         /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpRequestHeaders"/></remarks>
-        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the request header on.</param>
         /// <param name="headerName">The name of the header to locate on the request.</param>
         /// <returns>true when the request contains a header with the specified name; otherwise, false.</returns>
         public static bool HasRequestHeader(this HttpRequestMessage httpRequestMessage, string headerName)
@@ -120,7 +120,7 @@ namespace HttpClientTestHelpers
         /// Determines whether a specific header with a specific value is set on a request.
         /// </summary>
         /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpRequestHeaders"/></remarks>
-        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the request header on.</param>
         /// <param name="headerName">The name of the header to locate on the request.</param>
         /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
         /// <returns>true when the request contains a header with the specified name and value; otherwise, false.</returns>
@@ -148,8 +148,8 @@ namespace HttpClientTestHelpers
         /// Determines whether a specific header is set on a request.
         /// </summary>
         /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpContentHeaders"/></remarks>
-        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
-        /// <param name="headerName">The name of the header to locate on the request.</param>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the content header on.</param>
+        /// <param name="headerName">The name of the header to locate on the request content.</param>
         /// <returns>true when the request contains a header with the specified name; otherwise, false.</returns>
         public static bool HasContentHeader(this HttpRequestMessage httpRequestMessage, string headerName)
         {
@@ -175,8 +175,8 @@ namespace HttpClientTestHelpers
         /// Determines whether a specific header with a specific value is set on a request.
         /// </summary>
         /// <remarks>This method only checks headers in <see cref="System.Net.Http.Headers.HttpContentHeaders"/></remarks>
-        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
-        /// <param name="headerName">The name of the header to locate on the request.</param>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the content header on.</param>
+        /// <param name="headerName">The name of the header to locate on the request content.</param>
         /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
         /// <returns>true when the request contains a header with the specified name and value; otherwise, false.</returns>
         public static bool HasContentHeader(this HttpRequestMessage httpRequestMessage, string headerName, string headerValue)
@@ -223,8 +223,8 @@ namespace HttpClientTestHelpers
         /// <summary>
         /// Determines whether the request uri matches a pattern.
         /// </summary>
-        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct method on.</param>
-        /// <param name="pattern">A pattern to match with the request uri, support * as wildcards.</param>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct uri on.</param>
+        /// <param name="pattern">A pattern to match with the request uri, supports * as wildcards.</param>
         /// <returns>true when the request uri matches the pattern; otherwise, false.</returns>
         public static bool HasMatchingUri(this HttpRequestMessage httpRequestMessage, string pattern)
         {
@@ -239,6 +239,39 @@ namespace HttpClientTestHelpers
                 "" => false,
                 "*" => true,
                 _ => Matches(httpRequestMessage.RequestUri.AbsoluteUri, pattern),
+            };
+        }
+
+        /// <summary>
+        /// Determines whether the request content matches a string pattern.
+        /// </summary>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to check the correct content on.</param>
+        /// <param name="pattern">A pattern to match the request content, supports * as wildcards.</param>
+        /// <returns>true when the request content matches the pattern; otherwise, false.</returns>
+        public static bool HasContent(this HttpRequestMessage httpRequestMessage, string pattern)
+        {
+            if (httpRequestMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpRequestMessage));
+            }
+
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            if (httpRequestMessage.Content == null)
+            {
+                return false;
+            }
+
+            var stringContent = httpRequestMessage.Content.ReadAsStringAsync().Result;
+
+            return pattern switch
+            {
+                "" => stringContent == pattern,
+                "*" => true,
+                _ => Matches(stringContent, pattern),
             };
         }
 

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageAsserterTests.cs
@@ -555,6 +555,47 @@ namespace HttpClientTestHelpers.Tests
             Assert.IsType<HttpRequestMessageAsserter>(result);
         }
 
+#nullable disable
+        [Fact]
+        public void WithConten_NullPattern_ThrowsArgumentNullException()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContent(null));
+
+            Assert.Equal("pattern", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void WithContent_RequestWithNotMatchingContent_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        {
+            var request = new HttpRequestMessage
+            {
+                Content = new StringContent("")
+            };
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContent("some content"));
+
+            Assert.Equal("Expected at least one request to be made with content 'some content', but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void WithContent_RequestWithMatchingContent_ReturnsHttpRequestMessageAsserter()
+        {
+            var request = new HttpRequestMessage
+            {
+                Content = new StringContent("")
+            };
+            var sut = new HttpRequestMessageAsserter(new[] { request });
+
+            var result = sut.WithContent("");
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
         [Fact]
         public void Times_ValueLessThan0_ThrowsArgumentException()
         {

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContent.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContent.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Xunit;
+
+namespace HttpClientTestHelpers.Tests
+{
+    public partial class HttpRequestMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasContent_NullRequest_ThrowsArgumentNullException()
+        {
+            HttpRequestMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContent(""));
+            Assert.Equal("httpRequestMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasContent_NullExpectedContent_ThrowsArgumentNullException()
+        {
+            using var sut = new HttpRequestMessage();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContent(null));
+            Assert.Equal("pattern", exception.ParamName);
+        }
+#nullable enable
+
+        [Fact]
+        public void HasContent_NoContent_ReturnsFalse()
+        {
+            using var sut = new HttpRequestMessage();
+
+            Assert.False(sut.HasContent(""));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Some text")]
+        [InlineData("{\"key\":\"value\"}")]
+        public void HasContent_ExactlyMatchingStringContent_ReturnsTrue(string content)
+        {
+            using var sut = new HttpRequestMessage
+            {
+                Content = new StringContent(content)
+            };
+
+            Assert.True(sut.HasContent(content));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Some text")]
+        [InlineData("{\"key\":\"value\"}")]
+        public void HasContent_NotMatchingStringContent_ReturnsFalse(string content)
+        {
+            using var sut = new HttpRequestMessage
+            {
+                Content = new StringContent("Example content")
+            };
+
+            Assert.False(sut.HasContent(content));
+        }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("username=*&password=*")]
+        [InlineData("*admin*")]
+        public void HasContent_MatchingPattern_ReturnsTrue(string pattern)
+        {
+            using var sut = new HttpRequestMessage
+            {
+                Content = new StringContent("username=admin&password=admin")
+            };
+
+            Assert.True(sut.HasContent(pattern));
+        }
+
+        [Theory]
+        [InlineData("test")]
+        public void HasContent_NotMatchingPattern_ReturnsFalse(string pattern)
+        {
+            using var sut = new HttpRequestMessage
+            {
+                Content = new StringContent("username=admin&password=admin")
+            };
+
+            Assert.False(sut.HasContent(pattern));
+        }
+    }
+}

--- a/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContent.cs
+++ b/test/HttpClientTestHelpers.Tests/HttpRequestMessageExtensionsTests.HasContent.cs
@@ -79,7 +79,8 @@ namespace HttpClientTestHelpers.Tests
         }
 
         [Theory]
-        [InlineData("test")]
+        [InlineData("admin")]
+        [InlineData("*test*")]
         public void HasContent_NotMatchingPattern_ReturnsFalse(string pattern)
         {
             using var sut = new HttpRequestMessage


### PR DESCRIPTION
Added the `HasContent` extension method, that checks if a `HttpRequestMessage` contains a specific string representation of content.
Added the `WithContent` method to the `HttpRequestMessageAsserter` to be able to simply assert the string content of the message.

Fixes #2 